### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,17 +29,17 @@
   },
   "homepage": "https://github.com/felixmosh/knex-paginate#readme",
   "peerDependencies": {
-    "knex": ">= 0.19.1"
+    "knex": ">=0.95.1"
   },
   "devDependencies": {
-    "@types/jest": "^24.0.12",
-    "@types/node": "^12.12.37",
-    "auto-changelog": "^1.16.4",
+    "@types/jest": "^26.0.20",
+    "@types/node": "^14.14.31",
+    "auto-changelog": "^2.2.1",
     "dotenv": "^8.2.0",
-    "jest": "^25.5.1",
+    "jest": "^26.6.3",
     "knex": "^0.21.1",
     "mysql": "^2.18.1",
-    "release-it": "^13.6.6"
+    "release-it": "^14.4.1"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
Hi @felixmosh! Thanks for this awesome library. 

Can we upgrade to latests versions? Seems like knex has [released 0.95.x just two days ago](http://knexjs.org/#changelog) ;-)

```
 @types/jest      ^24.0.12  →   ^26.0.20     
 @types/node     ^12.12.37  →  ^14.14.31     
 auto-changelog    ^1.16.4  →     ^2.2.1     
 jest              ^25.5.1  →    ^26.6.3     
 knex            >= 0.19.1  →   >=0.95.1     
 release-it        ^13.6.6  →    ^14.4.1 
```